### PR TITLE
Fix Supabase import URL

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>Soggy Potatoes</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1.40.0/dist/umd/supabase.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
   <meta charset="UTF-8">
   <link rel="stylesheet" href="style.css">
   <title>About - Soggy Potatoes</title>

--- a/cart.html
+++ b/cart.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>Soggy Potatoes</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1.40.0/dist/umd/supabase.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
   <meta charset="UTF-8">
   <link rel="stylesheet" href="style.css">
   <title>Cart - Soggy Potatoes</title>

--- a/forums.html
+++ b/forums.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>Forums - Soggy Potatoes</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1.40.0/dist/umd/supabase.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
 </head>
 <body>
 <nav style="display: flex; justify-content: space-between; align-items: center;">
@@ -23,7 +23,7 @@
 
 <script>
   const sdk = document.createElement("script");
-  sdk.src = "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1.40.0/dist/umd/supabase.min.js";
+  sdk.src = "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js";
   sdk.onload = async () => {
     const supabase = window.supabase.createClient(
       "https://cdkuwlmddbvgahadowwz.supabase.co",

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>Soggy Potatoes</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1.40.0/dist/umd/supabase.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
   <meta charset="UTF-8">
   <link rel="stylesheet" href="style.css">
   <title>Soggy Potatoes</title>

--- a/login.html
+++ b/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>Soggy Potatoes</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1.40.0/dist/umd/supabase.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
   <meta charset="UTF-8">
   <title>Login - Soggy Potatoes</title>
   <link rel="stylesheet" href="style.css">

--- a/shop.html
+++ b/shop.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>Soggy Potatoes</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1.40.0/dist/umd/supabase.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.6/dist/umd/supabase.min.js"></script>
   <meta charset="UTF-8">
   <title>Shop - Soggy Potatoes</title>
   <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
## Summary
- fix CDN URL for Supabase to a valid release

## Testing
- `npm view @supabase/supabase-js@2.39.6 version` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6842fe0e41c08321b12c16a8bece667b