### PR TITLE
Convert profile placeholder to SVG

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -2,14 +2,25 @@ const SUPABASE_URL = "https://cdkuwlmddbvgahadowwz.supabase.co";
 const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNka3V3bG1kZGJ2Z2FoYWRvd3d6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc1OTIzMTIsImV4cCI6MjA2MzE2ODMxMn0.z8M2fgghS59tJ16IxW97Jvq9uEg4NOBaZWov8iri7BY";
 
 const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+const PLACEHOLDER_IMG = 'images/profile-placeholder.svg';
+
+async function getAvatarUrl(userId) {
+  const { data, error } = await supabase.storage.from('avatars').download(userId);
+  if (data && !error) {
+    return URL.createObjectURL(data);
+  }
+  return PLACEHOLDER_IMG;
+}
 
 async function updateUserStatus() {
   const { data: { session } } = await supabase.auth.getSession();
   const container = document.getElementById("userStatus");
   if (!container) return;
   if (session && session.user) {
+    const avatarUrl = await getAvatarUrl(session.user.id);
     container.innerHTML = `
-      <div class="dropdown">
+      <div class="dropdown" style="text-align:center;">
+        <img src="${avatarUrl}" alt="Profile" class="avatar">
         <a href="profile.html" id="userName">${session.user.email}</a>
         <div class="dropdown-content">
           <a href="profile.html">Profile</a>

--- a/images/profile-placeholder.svg
+++ b/images/profile-placeholder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <circle cx="40" cy="26" r="16" fill="#bbb" />
+  <rect x="20" y="46" width="40" height="18" fill="#bbb" />
+</svg>

--- a/profile.html
+++ b/profile.html
@@ -19,8 +19,48 @@
 </nav>
 
 <h1>Profile</h1>
-<p>This is a placeholder profile page.</p>
+<div style="text-align:center;">
+  <img id="currentAvatar" class="avatar" src="images/profile-placeholder.svg" alt="Current profile picture">
+  <input type="file" id="avatarInput" accept="image/*">
+  <button id="uploadAvatarButton">Upload Profile Picture</button>
+</div>
 
 <script src="auth.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', async () => {
+    const { data: { session } } = await supabase.auth.getSession();
+    const avatarImg = document.getElementById('currentAvatar');
+
+    async function loadAvatar() {
+      if (session && session.user) {
+        const { data, error } = await supabase.storage.from('avatars').download(session.user.id);
+        if (data && !error) {
+          avatarImg.src = URL.createObjectURL(data);
+        } else {
+          avatarImg.src = 'images/profile-placeholder.svg';
+        }
+      }
+    }
+
+    await loadAvatar();
+
+    const uploadBtn = document.getElementById('uploadAvatarButton');
+    if (uploadBtn) {
+      uploadBtn.addEventListener('click', async () => {
+        const fileInput = document.getElementById('avatarInput');
+        if (!fileInput.files.length || !(session && session.user)) return;
+        const file = fileInput.files[0];
+        await supabase.storage.from('avatars').remove([session.user.id]);
+        const { error } = await supabase.storage.from('avatars').upload(session.user.id, file, { upsert: true });
+        if (!error) {
+          await loadAvatar();
+          await updateUserStatus();
+        } else {
+          alert('Upload failed: ' + error.message);
+        }
+      });
+    }
+  });
+</script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -138,3 +138,18 @@ img.avatar {
   display: block;
   margin: 0 auto 4px;
 }
+/* Cart page styles */
+.cart-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.cart-item input[type="number"] {
+  width: 60px;
+}
+
+.cart-item .item-total {
+  margin-left: auto;
+}

--- a/style.css
+++ b/style.css
@@ -96,6 +96,7 @@ button {
 button:hover {
   background-color: #ab47bc;
 }
+
 /* Dropdown menu styles */
 .dropdown {
   position: relative;

--- a/style.css
+++ b/style.css
@@ -129,3 +129,11 @@ button:hover {
 .dropdown:hover .dropdown-content {
   display: block;
 }
+
+img.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: block;
+  margin: 0 auto 4px;
+}


### PR DESCRIPTION
## Summary
- replace binary PNG placeholder with a text-based SVG
- update `auth.js` and `profile.html` references

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_684306c5915c832187e8a586ebfad211