### PR TITLE
Use signed URLs when loading avatars

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -5,9 +5,11 @@ const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
 const PLACEHOLDER_IMG = 'images/profile-placeholder.svg';
 
 async function getAvatarUrl(userId) {
-  const { data, error } = await supabase.storage.from('avatars').download(userId);
+  const { data, error } = await supabase.storage
+    .from('avatars')
+    .createSignedUrl(userId, 60);
   if (data && !error) {
-    return URL.createObjectURL(data);
+    return data.signedUrl;
   }
   return PLACEHOLDER_IMG;
 }

--- a/profile.html
+++ b/profile.html
@@ -33,9 +33,11 @@
 
     async function loadAvatar() {
       if (session && session.user) {
-        const { data, error } = await supabase.storage.from('avatars').download(session.user.id);
+        const { data, error } = await supabase.storage
+          .from('avatars')
+          .createSignedUrl(session.user.id, 60);
         if (data && !error) {
-          avatarImg.src = URL.createObjectURL(data);
+          avatarImg.src = data.signedUrl;
         } else {
           avatarImg.src = 'images/profile-placeholder.svg';
         }


### PR DESCRIPTION
## Summary
- use Supabase `createSignedUrl` to fetch avatar images

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68430f49d4448321ba87a1b5d074ef6a