### PR TITLE
Fix avatar loading requests

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -5,11 +5,16 @@ const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
 const PLACEHOLDER_IMG = 'images/profile-placeholder.svg';
 
 async function getAvatarUrl(userId) {
-  const { data, error } = await supabase.storage
+  const { data: files, error: listError } = await supabase.storage
     .from('avatars')
-    .createSignedUrl(userId, 60);
-  if (data && !error) {
-    return data.signedUrl;
+    .list('', { search: userId });
+  if (!listError && files.some((f) => f.name === userId)) {
+    const { data, error } = await supabase.storage
+      .from('avatars')
+      .createSignedUrl(userId, 60);
+    if (data && !error) {
+      return data.signedUrl;
+    }
   }
   return PLACEHOLDER_IMG;
 }

--- a/profile.html
+++ b/profile.html
@@ -33,14 +33,19 @@
 
     async function loadAvatar() {
       if (session && session.user) {
-        const { data, error } = await supabase.storage
+        const { data: files, error: listError } = await supabase.storage
           .from('avatars')
-          .createSignedUrl(session.user.id, 60);
-        if (data && !error) {
-          avatarImg.src = data.signedUrl;
-        } else {
-          avatarImg.src = 'images/profile-placeholder.svg';
+          .list('', { search: session.user.id });
+        if (!listError && files.some(f => f.name === session.user.id)) {
+          const { data, error } = await supabase.storage
+            .from('avatars')
+            .createSignedUrl(session.user.id, 60);
+          if (data && !error) {
+            avatarImg.src = data.signedUrl;
+            return;
+          }
         }
+        avatarImg.src = 'images/profile-placeholder.svg';
       }
     }
 


### PR DESCRIPTION
## Summary
- check if avatar file exists before creating signed URLs
- load profile avatar the same way to avoid 400 errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684313cd96b08321b667385a28a6e360