### PR TITLE
Show thread metadata in forum list

### DIFF
--- a/forums.html
+++ b/forums.html
@@ -48,6 +48,9 @@ let currentUserEmail = 'Guest';
 
 function loadThreads() {
   threads = JSON.parse(localStorage.getItem('forumThreads') || '[]');
+  threads.forEach(t => {
+    if (!t.created) t.created = Date.now();
+  });
 }
 
 function saveThreads() {
@@ -60,7 +63,22 @@ function displayThreads() {
   threads.forEach(t => {
     const div = document.createElement('div');
     div.className = 'thread';
-    div.textContent = t.name;
+
+    const lastPost = t.posts.slice(-1)[0];
+    const meta = document.createElement('div');
+    meta.className = 'thread-meta';
+    meta.textContent =
+      `Posts: ${t.posts.length} | Created: ${new Date(t.created).toLocaleString()} | ` +
+      (lastPost
+        ? `Last: ${new Date(lastPost.time).toLocaleString()} by ${lastPost.user}`
+        : 'No posts yet');
+
+    const title = document.createElement('div');
+    title.className = 'thread-title';
+    title.textContent = t.name;
+
+    div.appendChild(title);
+    div.appendChild(meta);
     div.addEventListener('click', () => openThread(t.id));
     list.appendChild(div);
   });
@@ -100,7 +118,7 @@ document.getElementById('newThreadForm').addEventListener('submit', e => {
   e.preventDefault();
   const name = document.getElementById('threadName').value.trim();
   if(!name) return;
-  threads.push({ id: Date.now(), name, posts: [] });
+  threads.push({ id: Date.now(), name, created: Date.now(), posts: [] });
   saveThreads();
   displayThreads();
   e.target.reset();

--- a/style.css
+++ b/style.css
@@ -169,10 +169,22 @@ img.avatar {
   border-radius: 8px;
   margin-bottom: 10px;
   cursor: pointer;
+  display: flex;
+  flex-direction: column;
 }
 
 .thread-list .thread:hover {
   background: #f9f9f9;
+}
+
+.thread-list .thread-meta {
+  font-size: 0.85em;
+  color: #666;
+  margin-top: 4px;
+}
+
+.thread-list .thread-title {
+  font-weight: bold;
 }
 
 #threadView {


### PR DESCRIPTION
## Summary
- show thread post counts and timestamps
- add metadata for new threads
- style thread metadata in CSS

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68431432b9948321900c1a9e24d4ee31