### PR TITLE
Add product thumbnails to cart

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -58,10 +58,11 @@
       }
 
       for (const id in grouped) {
-        const { name, price, qty } = grouped[id];
+        const { name, price, qty, image } = grouped[id];
         const li = document.createElement("li");
         li.className = "cart-item";
         li.innerHTML = `
+          ${image ? `<img src="${image}" alt="${name}" class="cart-thumb">` : ''}
           <span class="item-name">${name}</span>
           <input type="number" min="1" value="${qty}" data-id="${id}" />
           <button class="remove-btn" data-id="${id}">Remove</button>
@@ -82,7 +83,7 @@
           const others = items.filter((it) => it.id !== id);
           const updated = [
             ...others,
-            ...Array.from({ length: newQty }, () => ({ id, name: baseItem.name, price: baseItem.price }))
+            ...Array.from({ length: newQty }, () => ({ id, name: baseItem.name, price: baseItem.price, image: baseItem.image }))
           ];
           localStorage.setItem("cart", JSON.stringify(updated));
           renderCart();

--- a/shop.html
+++ b/shop.html
@@ -37,8 +37,10 @@
     function addToCart(id, name, price, inputId) {
       const quantity = parseInt(document.getElementById(inputId).value);
       const cart = JSON.parse(localStorage.getItem("cart") || "[]");
+      const img = document.getElementById(inputId).parentElement.querySelector("img");
+      const image = img ? img.getAttribute("src") : "";
       for (let i = 0; i < quantity; i++) {
-        cart.push({ id, name, price });
+        cart.push({ id, name, price, image });
       }
       localStorage.setItem("cart", JSON.stringify(cart));
       alert(name + " × " + quantity + " added to cart!");

--- a/style.css
+++ b/style.css
@@ -154,6 +154,12 @@ img.avatar {
   margin-bottom: 8px;
 }
 
+.cart-item img {
+  width: 50px;
+  height: 50px;
+  object-fit: contain;
+}
+
 .cart-item input[type="number"] {
   width: 60px;
 }


### PR DESCRIPTION
## Summary
- store product image when adding items to the cart
- display item thumbnails in the cart view
- style cart item thumbnails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431994e9308321a44de3d708412c3c