### PR TITLE
Add user usernames

### DIFF
--- a/login.html
+++ b/login.html
@@ -56,6 +56,7 @@
           status.textContent = "Login failed: " + error.message;
         } else {
           status.textContent = "Logged in successfully!";
+          await promptForUsername();
           location.reload();
         }
       });
@@ -71,8 +72,33 @@
           status.textContent = "Signup failed: " + error.message;
         } else {
           status.textContent = "Signup successful! Check your email to confirm.";
+          await promptForUsername();
         }
       });
+    }
+
+    async function promptForUsername() {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!(session && session.user)) return;
+
+      const { data } = await supabase
+        .from('usernames')
+        .select('username')
+        .eq('id', session.user.id)
+        .single();
+      if (data && data.username) return; // already set
+
+      const username = prompt('Create a username');
+      if (!username) return;
+
+      const { error } = await setUsername(session.user.id, username.trim());
+      if (error) {
+        if (error === 'unavailable') {
+          alert('Username is unavailable');
+        } else {
+          alert('Failed to set username');
+        }
+      }
     }
 
   });

--- a/profile.html
+++ b/profile.html
@@ -25,11 +25,20 @@
   <button id="uploadAvatarButton">Upload Profile Picture</button>
 </div>
 
+<div style="text-align:center; margin-top:20px;">
+  <p>Your username: <span id="currentUsername">Loading...</span></p>
+  <input type="text" id="newUsername" placeholder="New username">
+  <button id="changeUsernameButton">Switch Username</button>
+</div>
+
 <script src="auth.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', async () => {
     const { data: { session } } = await supabase.auth.getSession();
     const avatarImg = document.getElementById('currentAvatar');
+    const currentUsername = document.getElementById('currentUsername');
+    const newUsernameInput = document.getElementById('newUsername');
+    const changeUsernameBtn = document.getElementById('changeUsernameButton');
 
     async function loadAvatar() {
       if (session && session.user) {
@@ -51,6 +60,19 @@
 
     await loadAvatar();
 
+    async function loadUsername() {
+      if (session && session.user) {
+        const { data } = await supabase
+          .from('usernames')
+          .select('username')
+          .eq('id', session.user.id)
+          .single();
+        currentUsername.textContent = data ? data.username : 'None';
+      }
+    }
+
+    await loadUsername();
+
     const uploadBtn = document.getElementById('uploadAvatarButton');
     if (uploadBtn) {
       uploadBtn.addEventListener('click', async () => {
@@ -65,6 +87,28 @@
         } else {
           alert('Upload failed: ' + error.message);
         }
+      });
+    }
+
+    if (changeUsernameBtn) {
+      changeUsernameBtn.addEventListener('click', async () => {
+        if (!(session && session.user)) return;
+        const desired = newUsernameInput.value.trim();
+        if (!desired) return;
+
+        const { error } = await setUsername(session.user.id, desired);
+        if (error) {
+          if (error === 'unavailable') {
+            alert('Username is unavailable');
+          } else {
+            alert('Failed to update username');
+          }
+          return;
+        }
+
+        await loadUsername();
+        await updateUserStatus();
+        newUsernameInput.value = '';
       });
     }
   });


### PR DESCRIPTION
## Summary
- support creating and storing usernames
- show usernames when logged in
- prompt for username on signup/login
- allow changing username from profile page
- fix handler for changing username and handle errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68431e93a6c88321aecf21b425f552ed